### PR TITLE
Add chart zoom and custom tooltip with links to GB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1270,6 +1270,14 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.4.1.tgz",
       "integrity": "sha512-0R4mL7WiBcYoazIhrzSYnWcOw6RmrRn7Q4nKZNsBQZCBrlkZKodQbfeojCCo8eETPRCs1ZNTsAcZhIfyhyP61g=="
     },
+    "chartjs-plugin-zoom": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-zoom/-/chartjs-plugin-zoom-1.2.1.tgz",
+      "integrity": "sha512-2zbWvw2pljrtMLMXkKw1uxYzAne5PtjJiOZftcut4Lo3Ee8qUt95RpMKDWrZ+pBZxZKQKOD/etdU4pN2jxZUmg==",
+      "requires": {
+        "hammerjs": "^2.0.8"
+      }
+    },
     "chokidar": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
@@ -2314,6 +2322,11 @@
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+    },
+    "hammerjs": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+      "integrity": "sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ=="
     },
     "has": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@headlessui/react": "^1.3.0",
     "@heroicons/react": "^1.0.3",
     "chart.js": "^3.4.1",
+    "chartjs-plugin-zoom": "^1.2.1",
     "classnames": "^2.3.1",
     "date-fns": "^2.23.0",
     "md5": "^2.3.0",


### PR DESCRIPTION
This PR adds a custom tooltip with a link to the GB commit. The tooltip is shown on `click`. I haven't used GitHub's API to fetch the name of the PR yet.

It also adds `zoom` support and `pan` support if we are holding the `shift` button.


https://user-images.githubusercontent.com/16275880/193812132-c3fa4dd9-3d8f-45a3-bbbe-1f98520b34f4.mov

