### PR TITLE
Add a repository field per project to avoid hardcoding Gutenberg repository

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "nextjs",
+  "name": "codevitals",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/pages/api/project/[slug].js
+++ b/pages/api/project/[slug].js
@@ -5,7 +5,7 @@ const conn = new PSDB('main')
 export default async (req, res) => {
   const { slug } = req.query
   const [projects] = await conn.query(
-    'select project.id as id, project.name as name, project.slug as slug, count( DISTINCT metric.id ) as countMetrics from project join metric on metric.project_id = project.id where project.slug = ? GROUP BY project.id',
+    'select project.id as id, project.name as name, project.slug as slug, project.repository as repository, count( DISTINCT metric.id ) as countMetrics from project join metric on metric.project_id = project.id where project.slug = ? GROUP BY project.id',
     slug
   )
   if (!projects.length) {

--- a/pages/api/projects.js
+++ b/pages/api/projects.js
@@ -4,7 +4,7 @@ const conn = new PSDB('main')
 
 export default async (req, res) => {
   const [projects] = await conn.query(
-    'select project.id as id, project.name as name, project.slug as slug, count( DISTINCT metric.id ) as countMetrics from project join metric on metric.project_id = project.id group by project.id'
+    'select project.id as id, project.name as name, project.slug as slug, project.repository as repository, count( DISTINCT metric.id ) as countMetrics from project join metric on metric.project_id = project.id group by project.id'
   )
   res.statusCode = 200
   res.json(projects)

--- a/pages/project/[project_slug]/index.js
+++ b/pages/project/[project_slug]/index.js
@@ -21,7 +21,7 @@ const limits = [
   { label: 'All time', value: 0 }
 ]
 const MemoLine = memo(Line)
-function Metric({ metric }) {
+function Metric({ metric, repository }) {
   const chartRef = useRef(null)
   const [chartIsZoomed, setChartIsZoomed] = useState(false)
   const [currentLimit, setLimit] = useState(200)
@@ -164,7 +164,7 @@ function Metric({ metric }) {
         {!!perf?.length && (
           <>
             <MemoLine ref={chartRef} plugins={plugins} data={data} options={options} />
-            <GraphTooltip tooltipData={tooltipData} />
+            <GraphTooltip repository={repository} tooltipData={tooltipData} />
           </>
         )}
       </div>
@@ -259,7 +259,7 @@ function MetricCard({ metric, onSelect }) {
   )
 }
 
-function GraphTooltip({ tooltipData }) {
+function GraphTooltip({ repository, tooltipData }) {
   return (
     Number.isFinite(tooltipData.top) && (
       <div
@@ -281,7 +281,7 @@ function GraphTooltip({ tooltipData }) {
           {tooltipData.titleLines.map((title, i) => (
             <a
               key={i}
-              href={`https://github.com/WordPress/gutenberg/commit/${title}`}
+              href={`https://github.com/${repository}/commit/${title}`}
               target='blank'
               style={{ display: 'inline-block' }}
             >
@@ -300,7 +300,7 @@ function GraphTooltip({ tooltipData }) {
   )
 }
 
-function Metrics({ id }) {
+function Metrics({ id, repository }) {
   const { data: metrics } = useSWR('/api/metrics/' + id, fetcher)
   const [selectedMetric, setSelectedMetric] = useState()
   const displayedMetric = selectedMetric || metrics?.[0]
@@ -319,7 +319,7 @@ function Metrics({ id }) {
             ))}
           </dl>
         )}
-        {displayedMetric && <Metric metric={displayedMetric} />}
+        {displayedMetric && <Metric metric={displayedMetric} repository={repository} />}
       </Layout>
     </>
   )
@@ -334,7 +334,7 @@ function ProjectMetrics() {
     return null
   }
 
-  return <Metrics id={project.id} />
+  return <Metrics id={project.id} repository={project.repository} />
 }
 
 export default function Home() {


### PR DESCRIPTION
closes #15 

When you click on graphs, you can click the commit to access the commit in question in Github. These links were broken for the WordPress project because the repository was hard coded. This "repository" field has been added to the database and this PR updates the UI to use it.