### PR TITLE
Remove all time graphs

### DIFF
--- a/pages/api/evolution/[metric_id].js
+++ b/pages/api/evolution/[metric_id].js
@@ -1,4 +1,3 @@
-// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 import { PSDB } from 'planetscale-node'
 
 const conn = new PSDB('main')
@@ -7,9 +6,8 @@ export default async (req, res) => {
   const { metric_id, limit } = req.query
   const parsedLimit = parseInt(limit)
   const [perfs] = await conn.query(
-    'select * from perf where branch = "trunk" and metric_id = ? order by measured_at DESC' +
-      (parsedLimit && parsedLimit !== '0' ? ' limit ' + parsedLimit : ''),
-    metric_id
+    'select * from perf where branch = "trunk" and metric_id = ? order by measured_at DESC LIMIT ?',
+    [metric_id, parsedLimit]
   )
   perfs.reverse()
   res.statusCode = 200

--- a/pages/project/[project_slug]/index.js
+++ b/pages/project/[project_slug]/index.js
@@ -19,8 +19,8 @@ const plugins = [Tooltip]
 const formatNumber = (number) => number.toLocaleString(undefined, { maximumFractionDigits: 2 })
 const fetcher = (url) => fetch(url).then((res) => res.json())
 const limits = [
-  { label: '200 latest commits', value: 200 },
-  { label: 'All time', value: 0 }
+  { label: '200 commits', value: 200 },
+  { label: '1000 commits', value: 1000 }
 ]
 const MemoLine = memo(Line)
 function Metric({ metric, repository }) {


### PR DESCRIPTION
I started receiving emails about slow requests. I think that's because we were showing the "all time" graphs. I think these graphs become less useful over time so I updated the UI and replaced that tab with the latest "1000" commits graph. 