### PR TITLE
Add support for selecting metric via query param

### DIFF
--- a/pages/project/[[...slug]]/index.js
+++ b/pages/project/[[...slug]]/index.js
@@ -339,7 +339,7 @@ function Metrics({ id, repository }) {
       <Layout>
         {!metrics && <div className='w-full h-full flex flex-col items-center justify-center text-lg'>Loading...</div>}
         {metrics && !metrics.length && (
-          <div className='w-full flex flex-col items-center justify-center text-lg'>No data available.</div>
+          <div className='w-full h-full flex flex-col items-center justify-center text-lg'>No data available.</div>
         )}
         {!!metrics?.length && (
           <dl className='grid grid-cols-1 sm:grid-cols-5 bg-gray-50 border-b border-gray-200'>

--- a/pages/project/[[...slug]]/index.js
+++ b/pages/project/[[...slug]]/index.js
@@ -323,8 +323,8 @@ function Metrics({ id, repository }) {
   const router = useRouter()
   const [projectSlug, metricSlug] = router.query.slug
   const { data: metrics } = useSWR('/api/metrics/' + id, fetcher)
-  const [selectedMetric, setSelectedMetric] = useState()
-  const displayedMetric = selectedMetric || metrics?.[0]
+  const metricFromParam = metrics?.find((metric) => metric.key === metricSlug)
+  const displayedMetric = metricFromParam || metrics?.[0]
 
   useEffect(() => {
     // Set the metric slug in the URL if it's not already set.
@@ -347,10 +347,7 @@ function Metrics({ id, repository }) {
               <MetricCard
                 key={metric.id}
                 metric={metric}
-                onSelect={() => {
-                  setSelectedMetric(metric)
-                  router.push(`/project/${projectSlug}/${metric.key}`)
-                }}
+                onSelect={() => router.push(`/project/${projectSlug}/${metric.key}`)}
                 isActive={displayedMetric === metric}
               />
             ))}

--- a/pages/project/[project_slug]/index.js
+++ b/pages/project/[project_slug]/index.js
@@ -345,7 +345,7 @@ function Metrics({ id, repository }) {
         query: { ...router.query, metric: displayedMetric.key }
       },
       undefined,
-      {}
+      { scroll: false }
     )
   }
 

--- a/pages/project/[project_slug]/index.js
+++ b/pages/project/[project_slug]/index.js
@@ -181,12 +181,10 @@ function Metric({ metric, repository }) {
         </div>
       </div>
       <div className='p-4 m-8'>
-        {!!perf?.length && (
-          <>
-            <Line ref={chartRef} plugins={plugins} data={data} options={options} />
-            <GraphTooltip repository={repository} tooltipData={tooltipData} />
-          </>
-        )}
+        <>
+          <Line ref={chartRef} plugins={plugins} data={data} options={options} />
+          <GraphTooltip repository={repository} tooltipData={tooltipData} />
+        </>
       </div>
     </div>
   )

--- a/pages/project/[project_slug]/index.js
+++ b/pages/project/[project_slug]/index.js
@@ -205,10 +205,8 @@ function MetricCard({ metric, onSelect, isActive }) {
       role='button'
       onClick={onSelect}
       className={classnames(
-        'px-4 py-5 overflow-hidden sm:p-6 pointer bg-gray-50 hover:bg-gray-100 border-b border-r border-gray-200 border-t',
-        {
-          'bg-gray-100': isActive
-        }
+        'px-4 py-5 overflow-hidden sm:p-6 pointer hover:bg-gray-100 border-b border-r border-gray-200 border-t',
+        isActive ? 'bg-gray-100' : 'bg-gray-50'
       )}
       style={{ marginBottom: -1 }}
     >

--- a/pages/project/[project_slug]/index.js
+++ b/pages/project/[project_slug]/index.js
@@ -324,9 +324,31 @@ function GraphTooltip({ repository, tooltipData }) {
 }
 
 function Metrics({ id, repository }) {
+  const router = useRouter()
+  const { metric: queryKey } = router.query
   const { data: metrics } = useSWR('/api/metrics/' + id, fetcher)
   const [selectedMetric, setSelectedMetric] = useState()
-  const displayedMetric = selectedMetric || metrics?.[0]
+
+  let displayedMetric = selectedMetric
+
+  if (!displayedMetric) {
+    const queryMetric = metrics?.find((metric) => metric.key === queryKey)
+    const defaultMetric = metrics?.[0]
+
+    displayedMetric = queryMetric || defaultMetric
+  }
+
+  if (displayedMetric && queryKey !== displayedMetric.key) {
+    router.push(
+      {
+        pathname: router.pathname,
+        query: { ...router.query, metric: displayedMetric.key }
+      },
+      undefined,
+      {}
+    )
+  }
+
   return (
     <>
       <ZoomPlugin />


### PR DESCRIPTION
### What?

This PR adds support for selecting an active metric via URL param, for example:

```
http://localhost:3000/project/gutenberg/block-theme-timeToFirstByte
```

Apart from the above, this PR does the following: 
- Improves page stability by preventing the graph's canvas from being remounted on each metric change.
- Fixes setting the background color for an active metric card.

### How to test

1. Make sure setting the `metric` query param works both ways:
   - it should select the metric when passed in the URL and
   - it should update the URL when a metric is clicked.
2. Ensure the default `metric` query param is set when a dashboard opens. For example, clicking http://localhost:3000/project/gutenberg should update the URL to http://localhost:3000/project/gutenberg/firstBlock.
3. Make sure the graph canvas renders as expected when metrics change.
4. Make sure the background color for an active metric is set as expected.