### PR TITLE
Do not reset page scroll on metric change

### DIFF
--- a/pages/project/[[...slug]]/index.js
+++ b/pages/project/[[...slug]]/index.js
@@ -347,7 +347,7 @@ function Metrics({ id, repository }) {
               <MetricCard
                 key={metric.id}
                 metric={metric}
-                onSelect={() => router.push(`/project/${projectSlug}/${metric.key}`)}
+                onSelect={() => router.push(`/project/${projectSlug}/${metric.key}`, undefined, { scroll: false })}
                 isActive={displayedMetric === metric}
               />
             ))}


### PR DESCRIPTION
This fixes a behavior where clicking a metric card resets the page scroll to the top.