### PR TITLE
Ensure first displayed metric is a visible one

### DIFF
--- a/pages/project/[[...slug]]/index.js
+++ b/pages/project/[[...slug]]/index.js
@@ -327,9 +327,10 @@ function Metrics({ id, repository }) {
   const { data: metrics } = useSWR('/api/metrics/' + id, fetcher)
   const defaultMetrics = metrics?.filter((metric) => metric.default_visible !== 0)
   const metricFromParam = metrics?.find((metric) => metric.key === metricSlug)
-  const displayedMetric = metricFromParam || metrics?.[0]
-
   const [selectedMetrics, setSelectedMetrics] = useState(defaultMetrics)
+
+  const _selectedMetrics = selectedMetrics || defaultMetrics
+  const displayedMetric = metricFromParam || _selectedMetrics?.[0]
 
   useEffect(() => {
     // Set the metric slug in the URL if it's not already set.
@@ -338,7 +339,6 @@ function Metrics({ id, repository }) {
     }
   }, [metricSlug, displayedMetric])
 
-  const _selectedMetrics = selectedMetrics || defaultMetrics
 
   return (
     <>

--- a/pages/project/[[...slug]]/index.js
+++ b/pages/project/[[...slug]]/index.js
@@ -339,7 +339,6 @@ function Metrics({ id, repository }) {
     }
   }, [metricSlug, displayedMetric])
 
-
   return (
     <>
       <ZoomPlugin />


### PR DESCRIPTION
This is a quick follow-up to #32, props @felixarntz

The first displayed metric was still just the first in the list of all metrics, but by default you should only see the first of the _visible_ ones